### PR TITLE
add ABNF grammar support

### DIFF
--- a/examples/example.abnf
+++ b/examples/example.abnf
@@ -1,136 +1,40 @@
-abaAdsfASDFZ = %d23.14.51; sadlf s
-hello = sadf ;sadf sadf 
-hello = sadf | ;sadf sadf 
-hello = "sadf" hello  ;sadf sadf 
-hello = %x2d;
-hello = %b0110100;
-asdf asdf
-  
-symblol =;asdf   
-; zsd
-       ; as asdf 
-sad; asdf
-"hello"
-sdaasd
+; Sample ABNF code for testing the syntax highlighting rule output.
+; The code as the ABNF definition of ABNF as defined in RFC 5234
+; copied almost completely verbatim.
 
-ALPHA          =  %x41-5A / %x61-7A   ; A-Z / a-z
-
-BIT            =  "0" / "1"
-
-CHAR           =  %x01-7F
-                       ; any 7-bit US-ASCII character,
-                       ;  excluding NUL
-
-
-
-Crocker & Overell           Standards Track                    [Page 13]
-
-
-RFC 5234                          ABNF                      January 2008
-
-
-CR             =  %x0D
-                       ; carriage return
-CRLF           =  CR LF
-                       ; Internet standard newline
-CTL            =  %x00-1F / %x712123-123.1321
-                       ; controls
-DIGIT          =  %x30-39
-                       ; 0-9
-DQUOTE         =  %x22
-                       ; " (Double Quote)
-HEXDIG         =  DIGIT / "A" / "B" / "C" / "D" / "E" / "F"
-HTAB           =  %x09
-                       ; horizontal tab
-LF             =  %x0A
-                       ; linefeed
-LWSP           =  *(WSP / CRLF WSP)
-                       ; Use of this linear-white-space rule
-                       ;  permits lines containing only white
-                       ;  space that are no longer legal in
-                       ;  mail headers and have caused
-                       ;  interoperability problems in other
-                       ;  contexts.
-                       ; Do not use when defining mail
-                       ;  headers and use with caution in
-                       ;  other contexts.
-OCTET          =  %x00-FF
-                       ; 8 bits of data
-SP             =  %x20
-VCHAR          =  %x21-7E
-                       ; visible (printing) characters
-                       
-WSP            =  SP / HTAB
-                       ; white space
 rulelist       =  1*( rule / (*c-wsp c-nl) )
-rule           =  rulename defined-as elements c-nl
-                      ; continues if next line starts
-                      ;  with white space
+rule           =  rulename defined-as elements c-nl ; continues if next line starts with white space
 rulename       =  ALPHA *(ALPHA / DIGIT / "-")
+
+; basic rules definition and  incremental alternatives
 defined-as     =  *c-wsp ("=" / "=/") *c-wsp
-                       ; basic rules definition and
-                       ;  incremental alternatives
-
 elements       =  alternation *c-wsp
-
 c-wsp          =  WSP / (c-nl WSP)
-
-c-nl           =  comment / CRLF
-                       ; comment or newline
-
+c-nl           =  comment / CRLF    ; comment or newline
 comment        =  ";" *(WSP / VCHAR) CRLF
-
 alternation    =  concatenation
                   *(*c-wsp "/" *c-wsp concatenation)
-
 concatenation  =  repetition *(1*c-wsp repetition)
-
 repetition     =  [repeat] element
-
 repeat         =  1*DIGIT / (*DIGIT "*" *DIGIT)
-
 element        =  rulename / group / option /
                   char-val / num-val / prose-val
-
 group          =  "(" *c-wsp alternation *c-wsp ")"
-
 option         =  "[" *c-wsp alternation *c-wsp "]"
-
 char-val       =  DQUOTE *(%x20-21 / %x23-7E) DQUOTE
                        ; quoted string of SP and VCHAR
                        ;  without DQUOTE
-
 num-val        =  "%" (bin-val / dec-val / hex-val)
-
 bin-val        =  "b" 1*BIT
                   [ 1*("." 1*BIT) / ("-" 1*BIT) ]
                        ; series of concatenated bit values
                        ;  or single ONEOF range
-
 dec-val        =  "d" 1*DIGIT
                   [ 1*("." 1*DIGIT) / ("-" 1*DIGIT) ]
-
 hex-val        =  "x" 1*HEXDIG
                   [ 1*("." 1*HEXDIG) / ("-" 1*HEXDIG) ]
-                  
-                  
-postal-address   = name-part street zip-part
-
-name-part        = *(personal-part SP) last-name [SP suffix] CRLF
-name-part        =/ personal-part CRLF
-
-personal-part    = first-name / (initial ".")
-first-name       = *ALPHA
-initial          = ALPHA
-last-name        = *ALPHA
-suffix           = ("Jr." / "Sr." / 1*("I" / "V" / "X"))
-
-street           = [apt SP] house-num SP street-name CRLF
-apt              = 1*4DIGIT
-house-num        = 1*8(DIGIT / ALPHA)
-street-name      = 1*VCHAR
-
-zip-part         = town-name "," SP state 1*2SP zip-code CRLF
-town-name        = 1*(ALPHA / SP)
-state            = 2ALPHA
-zip-code         = 5DIGIT ["-" 4DIGIT]
+prose-val      =  "<" *(%x20-3D / %x3F-7E) ">"
+                       ; bracketed string of SP and VCHAR
+                       ;  without angles
+                       ; prose description, to be used as
+                       ;  last resort

--- a/examples/example.abnf
+++ b/examples/example.abnf
@@ -1,0 +1,136 @@
+abaAdsfASDFZ = %d23.14.51; sadlf s
+hello = sadf ;sadf sadf 
+hello = sadf | ;sadf sadf 
+hello = "sadf" hello  ;sadf sadf 
+hello = %x2d;
+hello = %b0110100;
+asdf asdf
+  
+symblol =;asdf   
+; zsd
+       ; as asdf 
+sad; asdf
+"hello"
+sdaasd
+
+ALPHA          =  %x41-5A / %x61-7A   ; A-Z / a-z
+
+BIT            =  "0" / "1"
+
+CHAR           =  %x01-7F
+                       ; any 7-bit US-ASCII character,
+                       ;  excluding NUL
+
+
+
+Crocker & Overell           Standards Track                    [Page 13]
+
+
+RFC 5234                          ABNF                      January 2008
+
+
+CR             =  %x0D
+                       ; carriage return
+CRLF           =  CR LF
+                       ; Internet standard newline
+CTL            =  %x00-1F / %x712123-123.1321
+                       ; controls
+DIGIT          =  %x30-39
+                       ; 0-9
+DQUOTE         =  %x22
+                       ; " (Double Quote)
+HEXDIG         =  DIGIT / "A" / "B" / "C" / "D" / "E" / "F"
+HTAB           =  %x09
+                       ; horizontal tab
+LF             =  %x0A
+                       ; linefeed
+LWSP           =  *(WSP / CRLF WSP)
+                       ; Use of this linear-white-space rule
+                       ;  permits lines containing only white
+                       ;  space that are no longer legal in
+                       ;  mail headers and have caused
+                       ;  interoperability problems in other
+                       ;  contexts.
+                       ; Do not use when defining mail
+                       ;  headers and use with caution in
+                       ;  other contexts.
+OCTET          =  %x00-FF
+                       ; 8 bits of data
+SP             =  %x20
+VCHAR          =  %x21-7E
+                       ; visible (printing) characters
+                       
+WSP            =  SP / HTAB
+                       ; white space
+rulelist       =  1*( rule / (*c-wsp c-nl) )
+rule           =  rulename defined-as elements c-nl
+                      ; continues if next line starts
+                      ;  with white space
+rulename       =  ALPHA *(ALPHA / DIGIT / "-")
+defined-as     =  *c-wsp ("=" / "=/") *c-wsp
+                       ; basic rules definition and
+                       ;  incremental alternatives
+
+elements       =  alternation *c-wsp
+
+c-wsp          =  WSP / (c-nl WSP)
+
+c-nl           =  comment / CRLF
+                       ; comment or newline
+
+comment        =  ";" *(WSP / VCHAR) CRLF
+
+alternation    =  concatenation
+                  *(*c-wsp "/" *c-wsp concatenation)
+
+concatenation  =  repetition *(1*c-wsp repetition)
+
+repetition     =  [repeat] element
+
+repeat         =  1*DIGIT / (*DIGIT "*" *DIGIT)
+
+element        =  rulename / group / option /
+                  char-val / num-val / prose-val
+
+group          =  "(" *c-wsp alternation *c-wsp ")"
+
+option         =  "[" *c-wsp alternation *c-wsp "]"
+
+char-val       =  DQUOTE *(%x20-21 / %x23-7E) DQUOTE
+                       ; quoted string of SP and VCHAR
+                       ;  without DQUOTE
+
+num-val        =  "%" (bin-val / dec-val / hex-val)
+
+bin-val        =  "b" 1*BIT
+                  [ 1*("." 1*BIT) / ("-" 1*BIT) ]
+                       ; series of concatenated bit values
+                       ;  or single ONEOF range
+
+dec-val        =  "d" 1*DIGIT
+                  [ 1*("." 1*DIGIT) / ("-" 1*DIGIT) ]
+
+hex-val        =  "x" 1*HEXDIG
+                  [ 1*("." 1*HEXDIG) / ("-" 1*HEXDIG) ]
+                  
+                  
+postal-address   = name-part street zip-part
+
+name-part        = *(personal-part SP) last-name [SP suffix] CRLF
+name-part        =/ personal-part CRLF
+
+personal-part    = first-name / (initial ".")
+first-name       = *ALPHA
+initial          = ALPHA
+last-name        = *ALPHA
+suffix           = ("Jr." / "Sr." / 1*("I" / "V" / "X"))
+
+street           = [apt SP] house-num SP street-name CRLF
+apt              = 1*4DIGIT
+house-num        = 1*8(DIGIT / ALPHA)
+street-name      = 1*VCHAR
+
+zip-part         = town-name "," SP state 1*2SP zip-code CRLF
+town-name        = 1*(ALPHA / SP)
+state            = 2ALPHA
+zip-code         = 5DIGIT ["-" 4DIGIT]

--- a/grammars/abnf.cson
+++ b/grammars/abnf.cson
@@ -1,15 +1,34 @@
-fileTypes: ["src"]
+# syntax highlighting rule for Augmented Backus-Naur Form (ABNF)
+# ABNF is documented in RFC 5234. This is file applies rule very loosely
+# Original author: Jarmo Kivekas
+# Date: July 2015
+
+fileTypes: []
 name: "ABNF"
 patterns: [
+  # These ruels appear here as well as in the 'expression' rule
+  # because of how multi-line syntactic elements are handled
   {include: '#comment.line'}
+  {include: '#constant.numeric.hexadecimal'}
+  {include: '#constant.numeric.decimal'}
+  {include: '#constant.numeric.binary'}
+  {include: '#string.quoted.double'}
+  {include: '#constant.core-rule'}
   {
-    # 
+    name: 'keyword.operator.assignment'
+    match: '='
+  }
+  {
+    # liberally matches a rule definition line
+    # rule names start with a letter
     match: '^\\s*([a-zA-Z][-a-zA-Z0-9]*)\\s*(=)(.*)$'
     captures:
       '1':
         name: 'entity.name.function.bnf'
       '2':
         name: 'keyword.operator.assignment'
+      # the rules below are applied to everything on the right side
+      # of the assignment operator
       '3':
         name: 'expression'
         patterns:[
@@ -22,6 +41,7 @@ patterns: [
         ]
   }
 ]
+
 repository:
   # semi-colon end of line comment
   'comment.line':
@@ -29,6 +49,7 @@ repository:
     captures:
       '1':
         name: 'comment.line.semi-colon.bnf'
+  # sets of core-rules pre-defined by the language (Appendix B.)
   'constant.core-rule':
     match: '(ALPHA|BIT|CHAR|CR|CRLF|CTL|DIGIT|DQUOTE|HEXDIG|HTAB|LF|LWSP|OCTET|SP|VCHAR|WSP)'
     captures:
@@ -36,6 +57,8 @@ repository:
         name: 'constant.string.core-rule.bnf'
 
   # numeric constants like %d12-52 %b01011 %x0A.42.12
+  # the range (-) and concatenation (.) operator should
+  # not be mixed. However this rule recognizes eg. %d12-42.24
   'constant.numeric.hexadecimal':
     name: "constant.numeric.hexadecimal.bnf"
     match: '%x[0-9A-F]+([-\\.][0-9A-F]+)*'
@@ -45,19 +68,9 @@ repository:
   'constant.numeric.decimal':
     name: "constant.numeric.decimal.bnf"
     match: '%d[0-9]+([-\\.][0-9]+)*'
-  # String literals
   'string.quoted.double':  
     begin: '"'
     end: '"'
     name: 'string.quoted.double.bnf'
-  "rule-name":
-    match: "(<)(.*?)(>)"
-    captures:
-      "1":
-        name: "punctuation.rule-name.start.bnf"
-      "2":
-        name: "constant.other.symbol.bnf"
-      "3":
-        name: "punctuation.rule-name.end.bnf"
-scope: "text.bnf"
-scopeName: "text.bnf"
+scope: "source.abnf"
+scopeName: "source.abnf"

--- a/grammars/abnf.cson
+++ b/grammars/abnf.cson
@@ -1,0 +1,63 @@
+fileTypes: ["src"]
+name: "ABNF"
+patterns: [
+  {include: '#comment.line'}
+  {
+    # 
+    match: '^\\s*([a-zA-Z][-a-zA-Z0-9]*)\\s*(=)(.*)$'
+    captures:
+      '1':
+        name: 'entity.name.function.bnf'
+      '2':
+        name: 'keyword.operator.assignment'
+      '3':
+        name: 'expression'
+        patterns:[
+          {include: '#constant.numeric.hexadecimal'}
+          {include: '#constant.numeric.decimal'}
+          {include: '#constant.numeric.binary'}
+          {include: '#string.quoted.double'}
+          {include: '#constant.core-rule'}
+          {include: '#comment.line'}
+        ]
+  }
+]
+repository:
+  # semi-colon end of line comment
+  'comment.line':
+    match: '\\s*(;.*)$'
+    captures:
+      '1':
+        name: 'comment.line.semi-colon.bnf'
+  'constant.core-rule':
+    match: '(ALPHA|BIT|CHAR|CR|CRLF|CTL|DIGIT|DQUOTE|HEXDIG|HTAB|LF|LWSP|OCTET|SP|VCHAR|WSP)'
+    captures:
+      '1':
+        name: 'constant.string.core-rule.bnf'
+
+  # numeric constants like %d12-52 %b01011 %x0A.42.12
+  'constant.numeric.hexadecimal':
+    name: "constant.numeric.hexadecimal.bnf"
+    match: '%x[0-9A-F]+([-\\.][0-9A-F]+)*'
+  'constant.numeric.binary':
+    name: "constant.numeric.binary.bnf"
+    match: '%b[01]+([-\\.][10]+)*'
+  'constant.numeric.decimal':
+    name: "constant.numeric.decimal.bnf"
+    match: '%d[0-9]+([-\\.][0-9]+)*'
+  # String literals
+  'string.quoted.double':  
+    begin: '"'
+    end: '"'
+    name: 'string.quoted.double.bnf'
+  "rule-name":
+    match: "(<)(.*?)(>)"
+    captures:
+      "1":
+        name: "punctuation.rule-name.start.bnf"
+      "2":
+        name: "constant.other.symbol.bnf"
+      "3":
+        name: "punctuation.rule-name.end.bnf"
+scope: "text.bnf"
+scopeName: "text.bnf"

--- a/settings/language-abnf.cson
+++ b/settings/language-abnf.cson
@@ -1,0 +1,3 @@
+'.source.abnf':
+  'editor':
+    'commentStart': '; '

--- a/snippets/language-abfn.cson
+++ b/snippets/language-abfn.cson
@@ -1,0 +1,4 @@
+# "source.abnf":
+#   "Placeholder Rule":
+#     prefix: "place"
+#     body: '${1:first} ${2:second} $0'


### PR DESCRIPTION
Hey!

I've written grammar highlighting rules for Augmented BNF. As far as I've been able to test, it works as expected. There are still some language elements (such as operators) that could be added, but I'm still working on it. 

These are some of the elements it recognizes:
- `comment.line`
- `constant.numeric.hexadecimal` (including ranges like `%xAD-B0` etc.)
- `constant.numeric.decimal`
- `constant.numeric.binary`
- `string.quoted.double`
- `constant.core-rule` (`ALPHA`, `DIGIT` etc.)
- `keyword.operator.assignment`
- `entity.name.function.bnf` (the name of a rule when defining it)

This is how the ABNF highlighting currently looks with the 'One Dark' syntax theme:

![screenshot from 2015-07-20 23 36 03](https://cloud.githubusercontent.com/assets/3074453/8786829/497ae6ce-2f39-11e5-91c8-d7910f90efcc.png)

I realize there has been no work done on this package since it was first created two months ago. If this package has been abandoned, let me know and I won't keep bothering. And if it indeed is abandoned, I would also be happy to inherit it, if you are willing. Just to avoid having multiple language-bnf packages in atom. 

-- jarmo
