### PR TITLE
Add file type

### DIFF
--- a/grammars/abnf.cson
+++ b/grammars/abnf.cson
@@ -3,7 +3,9 @@
 # Original author: Jarmo Kivekas
 # Date: July 2015
 
-fileTypes: []
+fileTypes: [
+  "abnf"
+]
 name: "ABNF"
 patterns: [
   # These ruels appear here as well as in the 'expression' rule


### PR DESCRIPTION
The abnf syntax does not work if missing file type in abnf.cson, my Atom version is 1.6.2
